### PR TITLE
Support uploading files without making them public

### DIFF
--- a/lib/s3_storer_client/api.rb
+++ b/lib/s3_storer_client/api.rb
@@ -90,6 +90,7 @@ module S3StorerClient
         }
       }
 
+      defaults[:options][:makePublic] = @config.make_public if @config.respond_to? :make_public
       defaults[:options][:cloudfrontHost] = @config.cloudfront_host if @config.cloudfront_host
 
       defaults.merge(hash).to_json

--- a/lib/s3_storer_client/config.rb
+++ b/lib/s3_storer_client/config.rb
@@ -5,7 +5,7 @@ module S3StorerClient
       aws_access_key_id aws_secret_access_key s3_bucket s3_region
     ]
     OPTIONAL = %w[
-      cloudfront_host
+      cloudfront_host make_public
     ]
 
     attr_accessor *REQUIRED

--- a/spec/lib/s3_storer_client_spec/api_spec.rb
+++ b/spec/lib/s3_storer_client_spec/api_spec.rb
@@ -61,6 +61,35 @@ describe S3StorerClient::Api do
       expect(subject.store urls).to be_ok
     end
 
+    it "makes a request to the API with the given make public setting" do
+      stub_request(:post, "https://xxx:xxx@s3-storer.herokuapp.com/store")
+        .with(body: {
+            urls: urls,
+            options: {
+              awsAccessKeyId: described_class.config.aws_access_key_id,
+              awsSecretAccessKey: described_class.config.aws_secret_access_key,
+              s3Bucket: described_class.config.s3_bucket,
+              s3Region: described_class.config.s3_region,
+              makePublic: false
+            }
+          }
+        )
+        .to_return(
+          status: 200,
+          headers: {'Content-Type' => 'application/json'},
+          body: {
+            status: 'ok',
+            urls: response_urls
+          }.to_json
+        )
+
+      config = described_class.config
+      config.make_public = false
+      subject = described_class.new config
+
+      expect(subject.store urls).to be_ok
+    end
+
     it "makes a request to the API with the given cloud front" do
       stub_request(:post, "https://xxx:xxx@s3-storer.herokuapp.com/store")
         .with(body: {


### PR DESCRIPTION
The service is being updated to support this new option, since it is very bad to
assume that the files uploaded through this should always be public. The service
still defaults to making files public, but at least we now have a way to turn it
off.